### PR TITLE
Fix: Team Sorting Logic for Milestone Completion Times

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -107,9 +107,9 @@ const Index = () => {
     if (presentationMode) {
       if (elem.requestFullscreen) {
         elem.requestFullscreen();
-      } else if (typeof elem.webkitRequestFullscreen === 'function') {
+      } else if (typeof elem.webkitRequestFullscreen === "function") {
         elem.webkitRequestFullscreen(); // Safari
-      } else if (typeof elem.msRequestFullscreen === 'function') {
+      } else if (typeof elem.msRequestFullscreen === "function") {
         elem.msRequestFullscreen(); // IE11
       }
     } else {
@@ -120,9 +120,9 @@ const Index = () => {
         };
         if (document.exitFullscreen) {
           document.exitFullscreen();
-        } else if (typeof doc.webkitExitFullscreen === 'function') {
+        } else if (typeof doc.webkitExitFullscreen === "function") {
           doc.webkitExitFullscreen(); // Safari
-        } else if (typeof doc.msExitFullscreen === 'function') {
+        } else if (typeof doc.msExitFullscreen === "function") {
           doc.msExitFullscreen(); // IE11
         }
       }
@@ -143,11 +143,46 @@ const Index = () => {
       const aCompleted = a.milestones.filter((m) => m.completed).length;
       const bCompleted = b.milestones.filter((m) => m.completed).length;
 
+      // Primary sort: by number of completed milestones
       if (aCompleted !== bCompleted) {
-        return bCompleted - aCompleted; // More completed milestones first
+        return bCompleted - aCompleted;
       }
 
-      return a.totalTime - b.totalTime; // Faster completion time first
+      // Secondary sort: by most recent completion time for teams with same completion count
+      const aCompletedMilestones = a.milestones.filter(
+        (m) => m.completed && m.completedAt
+      );
+      const bCompletedMilestones = b.milestones.filter(
+        (m) => m.completed && m.completedAt
+      );
+
+      if (aCompletedMilestones.length > 0 && bCompletedMilestones.length > 0) {
+        // Get the most recent completion time for each team
+        const aLatestCompletion = Math.max(
+          ...aCompletedMilestones.map((m) => {
+            const time =
+              m.completedAt instanceof Date
+                ? m.completedAt.getTime()
+                : new Date(m.completedAt!).getTime();
+            return time;
+          })
+        );
+        const bLatestCompletion = Math.max(
+          ...bCompletedMilestones.map((m) => {
+            const time =
+              m.completedAt instanceof Date
+                ? m.completedAt.getTime()
+                : new Date(m.completedAt!).getTime();
+            return time;
+          })
+        );
+
+        // Earlier completion time comes first
+        return aLatestCompletion - bLatestCompletion;
+      }
+
+      // Tertiary sort: by team creation order (ID) if no completions
+      return parseInt(a.id) - parseInt(b.id);
     });
   }, [teams]);
 
@@ -271,24 +306,26 @@ const Index = () => {
                 <div className="flex items-center gap-2 text-5xl font-mono">
                   <span className="text-green-400">⏱️</span>
                   <span>
-                    {String(Math.floor(elapsed / 3600)).padStart(2, '0')}
-                    :{String(Math.floor((elapsed % 3600) / 60)).padStart(2, '0')}
-                    :{String(elapsed % 60).padStart(2, '0')}
+                    {String(Math.floor(elapsed / 3600)).padStart(2, "0")}:
+                    {String(Math.floor((elapsed % 3600) / 60)).padStart(2, "0")}
+                    :{String(elapsed % 60).padStart(2, "0")}
                   </span>
                 </div>
               )}
               {!presentationMode && (
                 <>
-                  {!timerStarted && (<button
-                    onClick={() => {
-                      setTimer(new Date());
-                      setTimerStarted(true);
-                    }}
-                    className="px-3 py-1 rounded bg-green-600 hover:bg-green-700 text-white text-sm font-semibold transition-colors mr-2"
-                    title="Start Timer"
-                  >
-                    Start Timer
-                  </button>)}
+                  {!timerStarted && (
+                    <button
+                      onClick={() => {
+                        setTimer(new Date());
+                        setTimerStarted(true);
+                      }}
+                      className="px-3 py-1 rounded bg-green-600 hover:bg-green-700 text-white text-sm font-semibold transition-colors mr-2"
+                      title="Start Timer"
+                    >
+                      Start Timer
+                    </button>
+                  )}
                   <button
                     onClick={handleResetData}
                     className="px-3 py-1 rounded bg-red-600 hover:bg-red-700 text-white text-sm font-semibold transition-colors mr-2"


### PR DESCRIPTION
## Description of changes

### 🛑 Problem 
- Teams with equal milestone counts were not sorting correctly by completion time. Team B (completed at 21:34:14) was showing after Team A (completed at 21:34:19).

### 🟢 Solution
- Fixed date handling in localStorage conversion from ISO strings to Date objects
- Improved sorting logic to properly compare completion timestamps
- Teams now sort correctly: more milestones first, then by earliest completion time

| Before | After |
|--------|--------|
| <img width="1440" height="900" alt="Screenshot 2025-07-25 at 10 02 43 PM" src="https://github.com/user-attachments/assets/86679ec5-b300-4b23-8efa-bdfc9eb8dfc0" /> | <img width="1440" height="900" alt="Screenshot 2025-07-25 at 10 02 10 PM" src="https://github.com/user-attachments/assets/684e13c1-2e9b-4205-a542-e2bef3e78a72" /> | 

## How to test

### Setup
- Checkout to this branch
- Run npm run dev
- Launch localhost:8080

### Quick Test Scenarios
#### Test 1: Basic Sorting
- Add teams: A, B, C
- Start timer
- Complete milestone 1 in order: C → B → A (wait 2-3 seconds between)
- Expected: Order should be C, B, A (earliest completion first)
#### Test 2: Mixed Progress
- Complete milestone 2 for team A only
- Expected: A moves to first (2 milestones > 1 milestone)
- Order: A (2), C (1, earlier), B (1, later)
#### Test 3: Page Refresh
- Refresh the page after Test 2
- Expected: Same order maintained, completion times preserved


## Checklist

- [x] Test new logic in local
- [x] Test in various modern browsers at various sizes
- [x] Test in various devices (phone, tablet, desktop)
- [x] Test in dark mode
- [x] Test using a keyboard